### PR TITLE
Patch run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,21 +1,23 @@
 #!/bin/sh
 
+NAME="root-pythia"
+
 run__prod () {
 	# prod mode
-	docker build --file Dockerfile -t root-pythia:latest .
-	docker run --rm --interactive --tty --detach --env-file .env.prod root-pythia:latest
+	docker build --file Dockerfile -t ${NAME}:latest .
+	docker run --rm --interactive --tty --detach --env-file .env.prod ${NAME}:latest
 }
 
 run__dev () {
 	# dev mode
-	docker build --file Dockerfile.dev -t root-pythia-dev:latest .
-	docker run --interactive --tty --env-file .env.dev --volume $(realpath -P ./src):/opt/root-pythia/src root-pythia-dev:latest
+	docker build --file Dockerfile.dev -t ${NAME}-dev:latest .
+	docker run --interactive --tty --env-file .env.dev --volume $(realpath -P ./src):/opt/${NAME}/src ${NAME}-dev:latest
 }
 
 run__watch () {
 	# watch mode
-	docker build --file Dockerfile.watch -t root-pythia-watch:latest .
-	docker run --interactive --tty --env-file .env.dev --volume $(realpath -P ./src):/opt/root-pythia/src root-pythia-watch:latest
+	docker build --file Dockerfile.watch -t ${NAME}-watch:latest .
+	docker run --interactive --tty --env-file .env.dev --volume $(realpath -P ./src):/opt/${NAME}/src ${NAME}-watch:latest
 }
 
 run() {

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 run__prod () {
 	# prod mode
 	docker build --file Dockerfile -t root-pythia:latest .
-	docker run --rm --interactive --tty --env-file .env.prod root-pythia:latest
+	docker run --rm --interactive --tty --detach --env-file .env.prod root-pythia:latest
 }
 
 run__dev () {

--- a/run.sh
+++ b/run.sh
@@ -9,13 +9,13 @@ run__prod () {
 run__dev () {
 	# dev mode
 	docker build --file Dockerfile.dev -t root-pythia-dev:latest .
-	docker run --rm --interactive --tty --env-file .env.dev --volume $(realpath -P ./src):/opt/root-pythia/src root-pythia-dev:latest
+	docker run --interactive --tty --env-file .env.dev --volume $(realpath -P ./src):/opt/root-pythia/src root-pythia-dev:latest
 }
 
 run__watch () {
 	# watch mode
 	docker build --file Dockerfile.watch -t root-pythia-watch:latest .
-	docker run --rm --interactive --tty --env-file .env.dev --volume $(realpath -P ./src):/opt/root-pythia/src root-pythia-watch:latest
+	docker run --interactive --tty --env-file .env.dev --volume $(realpath -P ./src):/opt/root-pythia/src root-pythia-watch:latest
 }
 
 run() {


### PR DESCRIPTION
After my experience with [iscsc.fr blog notify](https://github.com/iScsc/iscsc.fr-blog-notify) I added a `--detach` flag to the `docker run` in prod mode.
However I'm not convinced we need to remove the `--rm` in dev and watch modes, because there isn't `--detach` we'll see the logs directly, anyway it doesn't harm anybody to remove it and **could** proves useful in special situations.