### PR TITLE
Make refresh delay configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ LOG_LEVEL=INFO
 # get an API Key by logging in on Root-me then go to 'my settings'
 API_KEY_ROOTME=<Root-Me API key>
 API_URL=https://api.www.root-me.org/
+
+### Bot Configuration
+REFRESH_DELAY=    # in seconds ! (default value if not set here is 10 seconds)

--- a/src/bot/root_pythia_cogs.py
+++ b/src/bot/root_pythia_cogs.py
@@ -1,11 +1,11 @@
 import logging
 
+from os import getenv
+
 import discord
 from discord.ext import commands, tasks
 
 from pngmaker import NewValidatedChallenge
-
-from os import getenv
 
 REFRESH_DELAY = int(getenv("REFRESH_DELAY") or "10")    # in seconds !
 
@@ -84,7 +84,6 @@ class RootPythiaCommands(commands.Cog, name=NAME):
             f"{user} \nPoints: {user.score}\nRank: {user.rank}\nLast Solves: <TO BE COMPLETED>"
         )
 
-    # TODO: make the resfresh delay configurable
     @tasks.loop(seconds=REFRESH_DELAY)
     async def check_new_solves(self):
         self.logger.info("Checking for new solves...")

--- a/src/bot/root_pythia_cogs.py
+++ b/src/bot/root_pythia_cogs.py
@@ -5,8 +5,11 @@ from discord.ext import commands, tasks
 
 from pngmaker import NewValidatedChallenge
 
-NAME = "RootPythiaCommands"
+from os import getenv
 
+REFRESH_DELAY = int(getenv("REFRESH_DELAY") or "10")    # in seconds !
+
+NAME = "RootPythiaCommands"
 
 class RootPythiaCommands(commands.Cog, name=NAME):
     """
@@ -82,7 +85,7 @@ class RootPythiaCommands(commands.Cog, name=NAME):
         )
 
     # TODO: make the resfresh delay configurable
-    @tasks.loop(seconds=10)
+    @tasks.loop(seconds=REFRESH_DELAY)
     async def check_new_solves(self):
         self.logger.info("Checking for new solves...")
 


### PR DESCRIPTION
Fix #20.
By default, bot refresh time is still 10 seconds.
It can be modified in the .env file.