### PR TITLE
Feat/help command

### DIFF
--- a/src/bot/custom_help_command.py
+++ b/src/bot/custom_help_command.py
@@ -1,0 +1,65 @@
+import discord
+from discord.ext.commands import HelpCommand
+
+
+class RootPythiaHelpCommand(HelpCommand):
+    """
+    Implementation of HelpCommand
+
+    HelpCommand.send_bot_help(mapping) that gets called with <prefix>help
+    HelpCommand.send_command_help(command) that gets called with <prefix>help <command>
+    HelpCommand.send_group_help(group) that gets called with <prefix>help <group>
+    HelpCommand.send_cog_help(cog) that gets called with <prefix>help <cog>
+    """
+
+    def get_command_signature(self, command):
+        return '%s %s' % (command.qualified_name, command.signature)
+
+    async def send_bot_help(self, mapping):
+        # color attribute sets color of the border on the left
+        embed = discord.Embed(title="Help", color=discord.Color.blurple())
+
+        for cog, cmds in mapping.items():
+            # Commands a user can't use are filtered
+            filtered_cmds = await self.filter_commands(cmds, sort=True)
+            cmd_signatures = [self.get_command_signature(cmd) for cmd in filtered_cmds]
+
+            if cmd_signatures:
+                cog_name = getattr(cog, "qualified_name", "No Category")
+                embed.add_field(name=cog_name, value="\n".join(cmd_signatures), inline=False)
+
+        await self.get_destination().send(embed=embed)
+
+    async def send_command_help(self, command):
+        embed = discord.Embed(title=self.get_command_signature(command), color=discord.Color.blurple())
+
+        if command.help:
+            embed.description = command.help
+        if alias := command.aliases:
+            embed.add_field(name="Aliases", value=", ".join(alias), inline=False)
+
+        await self.get_destination().send(embed=embed)
+
+    async def send_group_help(self, group):
+        embed = discord.Embed(title=self.get_command_signature(group), description=group.help, color=discord.Color.blurple())
+
+        if filtered_commands := await self.filter_commands(group.commands):
+            for command in filtered_commands:
+                embed.add_field(name=self.get_command_signature(command), value=command.help or "No Help Message Found... ")
+
+        await self.get_destination().send(embed=embed)
+
+    async def send_cog_help(self, cog):
+        embed = discord.Embed(title=cog.qualified_name or "No Category", description=cog.description, color=discord.Color.blurple())
+
+        if filtered_commands := await self.filter_commands(cog.get_commands()):
+            for command in filtered_commands:
+                embed.add_field(name=self.get_command_signature(command), value=command.help or "No Help Message Found... ", inline=False)
+
+        await self.get_destination().send(embed=embed)
+
+    async def send_error_message(self, error):
+        embed = discord.Embed(title="Error", description=error, color=discord.Color.red())
+        channel = self.get_destination()
+
+        await channel.send(embed=embed)

--- a/src/bot/root_pythia_bot.py
+++ b/src/bot/root_pythia_bot.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 
 from api.rootme_api import RootMeAPIManager
 from api.rate_limiter import RateLimiter
+from bot.custom_help_command import RootPythiaHelpCommand
 from bot.root_pythia_cogs import RootPythiaCommands
 from bot.dummy_db_manager import DummyDBManager
 
@@ -34,19 +35,23 @@ def craft_intents():
     # enable guild messages related events
     # More info: https://docs.pycord.dev/en/stable/api/data_classes.html#discord.Intents.guild_messages
     intents.guild_messages = True
-    
+
     return intents
 
 
 ########### Create bot object #################
 _DESCRIPTION = (
-    "RootPythia is a Discord bot fetching RootMe API to notify everyone"
+    "RootPythia is a Discord bot fetching RootMe API to notify everyone "
     "when a user solves a new challenge!"
 )
 _PREFIX = "!"
 _INTENTS = craft_intents()
 
-BOT = commands.Bot(command_prefix=_PREFIX, description=_DESCRIPTION, intents=_INTENTS, help_command=commands.DefaultHelpCommand())
+BOT = commands.Bot(
+        command_prefix=_PREFIX,
+        description=_DESCRIPTION,
+        intents=_INTENTS,
+        help_command=RootPythiaHelpCommand())
 
 # Create Bot own logger, each Cog will also have its own
 BOT.logger = logging.getLogger(__name__)

--- a/src/bot/root_pythia_bot.py
+++ b/src/bot/root_pythia_bot.py
@@ -17,21 +17,24 @@ CHANNEL_ID = getenv("CHANNEL_ID")
 
 
 def craft_intents():
-    # Intents int: 19456 means:
-    # - Send messages
-    # - Embed Links
-    # - Read messages/View Channels
-    # configured in the discord dev portal https://discord.com/developers/applications
-    # Notice that the bot doesn't required the intent "Send messages in threads"
-    intents = discord.Intents(value=19456)
+    """Function that enables necessary intents for the bot"""
 
-    # Disable privilegied and enbale message_content privilegied intent to enable commands
+    # Disable everything
+    intents = discord.Intents.none()
+    # enable guild related events
+    # More info: https://docs.pycord.dev/en/stable/api/data_classes.html#discord.Intents.guilds
+    intents.guilds = True
+
+    # Warning: message_content is a privileged intents
+    # you must authorize it in the discord dev portal https://discord.com/developers/applications
+    # enbale message_content privilegied intent to enable commands
+    # More info: https://docs.pycord.dev/en/stable/api/data_classes.html#discord.Intents.message_content
     intents.message_content = True
-    intents.messages = True
-    intents.typing = False
-    intents.guild_typing = False
-    intents.presences = False
 
+    # enable guild messages related events
+    # More info: https://docs.pycord.dev/en/stable/api/data_classes.html#discord.Intents.guild_messages
+    intents.guild_messages = True
+    
     return intents
 
 
@@ -43,7 +46,7 @@ _DESCRIPTION = (
 _PREFIX = "!"
 _INTENTS = craft_intents()
 
-BOT = commands.Bot(command_prefix=_PREFIX, description=_DESCRIPTION, intents=_INTENTS)
+BOT = commands.Bot(command_prefix=_PREFIX, description=_DESCRIPTION, intents=_INTENTS, help_command=commands.DefaultHelpCommand())
 
 # Create Bot own logger, each Cog will also have its own
 BOT.logger = logging.getLogger(__name__)

--- a/src/bot/root_pythia_bot.py
+++ b/src/bot/root_pythia_bot.py
@@ -92,3 +92,9 @@ async def on_error(event, *args, **kwargs):
         await BOT.channel.send(f"{event} event failed, please check logs for more details")
 
         BOT.logger.exception("Unhandled exception in '%s' event", event)
+
+
+@BOT.event
+async def on_command(ctx):
+    """Add logging when a command is triggered by a user"""
+    BOT.logger.info("'%s' command triggered by '%s'", ctx.command, ctx.author)

--- a/src/bot/root_pythia_cogs.py
+++ b/src/bot/root_pythia_cogs.py
@@ -26,14 +26,6 @@ class RootPythiaCommands(commands.Cog, name=NAME):
         # pylint: disable-next=no-member
         self.check_new_solves.start()
 
-    async def log_command_call(self, ctx):
-        # Maybe we should use the on_command event
-        # https://discordpy.readthedocs.io/en/stable/ext/commands/api.html?highlight=cog#discord.discord.ext.commands.on_command
-        # the logging would be implicit, no need of a redundant @commands.before_invoke(...) on
-        # each command. But right now I prefer to stick with this explicit solution
-        self.logger.info("'%s' command triggered by '%s'", ctx.command, ctx.author)
-
-    @commands.before_invoke(log_command_call)
     @commands.command(name="status")
     async def status(self, ctx):
         """
@@ -87,7 +79,6 @@ class RootPythiaCommands(commands.Cog, name=NAME):
         self.logger.info("Add user '%s'", user)
         await ctx.message.channel.send(f"{user} added!\nPoints: {user.score}")
 
-    @commands.before_invoke(log_command_call)
     @commands.command(name="addusers")
     async def addusers(self, ctx, *user_ids):
         """
@@ -109,7 +100,6 @@ class RootPythiaCommands(commands.Cog, name=NAME):
             # should continue here (ex: multiple users but only one can be wrong)
             await self.base_add_one_user(ctx, user_id)
 
-    @commands.before_invoke(log_command_call)
     @commands.command(name="adduser")
     async def adduser(self, ctx, user_id: int):
         """
@@ -117,7 +107,6 @@ class RootPythiaCommands(commands.Cog, name=NAME):
         """
         await self.base_add_one_user(ctx, user_id)
 
-    @commands.before_invoke(log_command_call)
     @commands.command(name="getuser")
     async def getuser(self, ctx, user_id: int):
         """


### PR DESCRIPTION
This PR solves #15 issue.

Problem was the bot didn't have the **guild intent** which is necessary for the `help` command (didn't find it on the internet so I did find it by trying repeatedly with different intents...).

This PR brings:
 - A refactor of `craft_intent` function where intents accorded to the bot are clearly stated (it was impossible for me to understand what intents were linked to the value passed in argument to the `Intent()` constructor.
 - A custom HelpCommand which implements the class HelpCommand of the `discord` library. It is very simple for now and has to be considered as a base for future and more complex implementation.
 - As the HelpCommand implementation is directly given to the `Bot()` constructor, the `help` command was not in the `COG` and couldn't be subject to logging with the `before_invoke` decorator. This is why, I added logging into the `on_command` event. Then, logging is automatically done when a command is triggered