### PR TITLE
Isolate bot channel

### DIFF
--- a/src/bot/root_pythia_bot.py
+++ b/src/bot/root_pythia_bot.py
@@ -13,7 +13,7 @@ from bot.root_pythia_cogs import RootPythiaCommands
 from bot.dummy_db_manager import DummyDBManager
 
 
-CHANNEL_ID = getenv("CHANNEL_ID")
+CHANNEL_ID = int(getenv("CHANNEL_ID"))
 
 
 def craft_intents():
@@ -50,6 +50,9 @@ BOT.logger = logging.getLogger(__name__)
 
 
 ########### Setup bot events response ###############
+@BOT.check
+def is_my_channel(ctx):
+    return ctx.channel.id == CHANNEL_ID
 
 
 @BOT.event

--- a/src/bot/root_pythia_bot.py
+++ b/src/bot/root_pythia_bot.py
@@ -13,7 +13,13 @@ from bot.root_pythia_cogs import RootPythiaCommands
 from bot.dummy_db_manager import DummyDBManager
 
 
-CHANNEL_ID = int(getenv("CHANNEL_ID"))
+CHANNEL_ID = getenv("CHANNEL_ID")
+if CHANNEL_ID.isnumeric():
+    CHANNEL_ID = int(CHANNEL_ID)
+else:
+    logging.warning(
+        "CHANNEL_ID environment variable is either not set or not an integer: %s", CHANNEL_ID
+    )
 
 
 def craft_intents():

--- a/src/bot/root_pythia_bot.py
+++ b/src/bot/root_pythia_bot.py
@@ -14,7 +14,7 @@ from bot.dummy_db_manager import DummyDBManager
 
 
 CHANNEL_ID = getenv("CHANNEL_ID")
-if CHANNEL_ID.isnumeric():
+if CHANNEL_ID is not None and CHANNEL_ID.isnumeric():
     CHANNEL_ID = int(CHANNEL_ID)
 else:
     logging.warning(

--- a/src/bot/root_pythia_cogs.py
+++ b/src/bot/root_pythia_cogs.py
@@ -4,6 +4,7 @@ from os import getenv
 
 import discord
 from discord.ext import commands, tasks
+from discord.ext.commands.errors import CheckFailure
 
 from pngmaker import NewValidatedChallenge
 
@@ -146,6 +147,16 @@ class RootPythiaCommands(commands.Cog, name=NAME):
 
     @commands.Cog.listener()
     async def on_command_error(self, ctx, error):
+        if isinstance(error, CheckFailure):
+            self.logger.warning(
+                "discord.ext.commands.errors.CheckFailure (is_my_channel?)"
+                " was captured by on_command_error: some global check failed"
+                " for command: '%s' in channel ID '%s'",
+                ctx.command,
+                ctx.channel.id,
+            )
+            return
+
         await ctx.send("Command failed, please check logs for more details")
         await self.verbose_if_idle(ctx)
 


### PR DESCRIPTION
This PR adds a little global check in `root_pythia_bot.py` that prevents the bot to respond in another channel than the one it is assign to. 
This is really annoying when a development instance is up to have both bots (production and development) respondoing to every command, it can also mess with the prod bot DB.
The global check returns false if the context channel (the one form which the command is triggered) ID is different from CHANNEL_ID (the channel where the bot ping on new solves), making the command to be aborted, raisign an exception caught in `on_command_error` and ignored after logging a warning

**TODO**: this could be cool to make this behavior configurable in .env or other configuration (even dynamic with some bot API?)