### PR TITLE
Make logging persistent by logging to files on host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ CHANNEL_ID=XXX
 ### Logging
 # accept integer or valid strings as described in the doc: https://docs.python.org/3/library/logging.html#logging.Logger.setLevel
 LOG_LEVEL=INFO
+LOG_FOLDER=path/to/log/folder
 
 ### Root-me API
 # get an API Key by logging in on Root-me then go to 'my settings'

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ CHANNEL_ID=XXX
 LOG_LEVEL=INFO
 LOG_FOLDER=path/to/log/folder
 
+# [OPTIONAL] in Bytes, the maximum size a log file can grow (default is 10e6)
+LOG_FILE_SIZE_MAX=
+# [OPTIONAL] the maximum number of log file generated, if exceeded the older are removed (default is 5)
+LOG_FILES_NUMBER=
+
+
 ### Root-me API
 # get an API Key by logging in on Root-me then go to 'my settings'
 API_KEY_ROOTME=<Root-Me API key>

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ LOG_FOLDER=path/to/log/folder
 LOG_FILE_SIZE_MAX=
 # [OPTIONAL] the maximum number of log file generated, if exceeded the older are removed (default is 5)
 LOG_FILES_NUMBER=
+# Note that if either of the previous variables are set to 0 the log file will grow indefinitely
 
 
 ### Root-me API

--- a/.env.example
+++ b/.env.example
@@ -3,13 +3,13 @@ MODE=dev|prod
 
 
 ### Discord env var
-
 # You can follow https://realpython.com/how-to-make-a-discord-bot-python/#creating-an-application to get a discord token
 DISCORD_TOKEN=XXX
 
 # The ID of the channel where the bot should send the Root-Me new solves and news
 # You can follow https://turbofuture.com/internet/Discord-Channel-ID to get your channel ID
 CHANNEL_ID=XXX
+
 
 ### Logging
 # accept integer or valid strings as described in the doc: https://docs.python.org/3/library/logging.html#logging.Logger.setLevel
@@ -21,7 +21,9 @@ LOG_FOLDER=path/to/log/folder
 API_KEY_ROOTME=<Root-Me API key>
 API_URL=https://api.www.root-me.org/
 
+# [OPTIONAL] the maximum number of time a single request is retried (if relevant)
 MAX_API_ATTEMPT=5
 
 ### Bot Configuration
-REFRESH_DELAY=    # in seconds ! (default value if not set here is 10 seconds)
+# [OPTIONAL] in seconds, the delay between new solve checking (default is 10)
+REFRESH_DELAY=

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 **/.env
 **/.env.prod
 **/.env.dev
+
+# Logs
+logs/**

--- a/run.sh
+++ b/run.sh
@@ -6,10 +6,10 @@ run__prod () {
 	# prod mode
 	docker build --file Dockerfile -t ${NAME}:latest .
 
-	. .env.prod
+	source ./.env.prod
 	docker run --rm --interactive --tty \
 	--detach \
-	--volume $(realpath -P ${LOG_FOLDER}):/opt/${NAME}/logs
+	--volume $(realpath -P ${LOG_FOLDER}):/opt/${NAME}/logs \
 	--env-file .env.prod \
 	--name ${NAME} \
 	${NAME}:latest

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,8 @@ NAME="root-pythia"
 run__prod () {
 	# prod mode
 	docker build --file Dockerfile -t ${NAME}:latest .
+
+	. .env.prod
 	docker run --rm --interactive --tty \
 	--detach \
 	--volume $(realpath -P ${LOG_FOLDER}):/opt/${NAME}/logs

--- a/run.sh
+++ b/run.sh
@@ -7,6 +7,7 @@ run__prod () {
 	docker build --file Dockerfile -t ${NAME}:latest .
 	docker run --rm --interactive --tty \
 	--detach \
+	--volume $(realpath -P ${LOG_FOLDER}):/opt/${NAME}/logs
 	--env-file .env.prod \
 	--name ${NAME} \
 	${NAME}:latest

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,11 @@ NAME="root-pythia"
 run__prod () {
 	# prod mode
 	docker build --file Dockerfile -t ${NAME}:latest .
-	docker run --rm --interactive --tty --detach --env-file .env.prod --name ${NAME} ${NAME}:latest
+	docker run --rm --interactive --tty \
+	--detach \
+	--env-file .env.prod \
+	--name ${NAME} \
+	${NAME}:latest
 }
 
 run__dev () {

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,11 @@ import logging
 from os import getenv
 import sys
 
+import discord
+
+from bot import BOT as root_pythia
+
+### Default global variables
 # in bytes
 DEFAULT_LOG_FILE_SIZE_MAX = 10e6
 # the number of files the rotating file handler will generate at max
@@ -9,10 +14,8 @@ DEFAULT_LOG_FILE_SIZE_MAX = 10e6
 # see https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler
 DEFAULT_LOG_FILES_NUMBER = 5
 
-import discord
 
-from bot import BOT as root_pythia
-
+### Global variables
 MODE = getenv("MODE")
 DISCORD_TOKEN = getenv("DISCORD_TOKEN")
 LOG_LEVEL = getenv("LOG_LEVEL")
@@ -24,14 +27,14 @@ try:
     LOG_FILE_SIZE_MAX = int(LOG_FILE_SIZE_MAX)
 except ValueError as exc:
     logging.exception("LOG_FILE_SIZE_MAX is not an integer")
-    exit(1)
+    sys.exit(1)
 
 LOG_FILES_NUMBER = getenv("LOG_FILES_NUMBER") or DEFAULT_LOG_FILES_NUMBER
 try:
     LOG_FILES_NUMBER = int(LOG_FILES_NUMBER)
 except ValueError as exc:
     logging.exception("LOG_FILES_NUMBER is not an integer")
-    exit(1)
+    sys.exit(1)
 
 
 def main():
@@ -39,7 +42,7 @@ def main():
     discord.utils.setup_logging(root=True, level=LOG_LEVEL)
 
     # Add a file handler to the root logger
-    file_handler = logging.RotatingFileHandler(
+    file_handler = logging.handlers.RotatingFileHandler(
         "./logs/RootPythia.log", mode="a", maxBytes=LOG_FILE_SIZE_MAX, backupCount=LOG_FILES_NUMBER
     )
     logging.getLogger().addHandler(file_handler)

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,11 @@ def main():
     # Setup a beautiful root logger
     discord.utils.setup_logging(root=True, level=LOG_LEVEL)
 
+    # Add a file handler to the root logger
+    file_handler = logging.RotatingFileHandler("./logs/RootPythia.log", mode='a', maxBytes=10e6, backupCount=5)
+    logging.getLogger().addHandler(file_handler)
+    logging.info("FileHandler added to root logger it will write to '%s'", file_handler.stream.name)
+
     # are these call secure??
     logging.debug("discord token: %s", DISCORD_TOKEN)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import logging
+import logging.handlers
 from os import getenv
 import sys
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,8 @@ from bot import BOT as root_pythia
 MODE = getenv("MODE")
 DISCORD_TOKEN = getenv("DISCORD_TOKEN")
 LOG_LEVEL = getenv("LOG_LEVEL")
+if LOG_LEVEL.isnumeric():
+    LOG_LEVEL = int(LOG_LEVEL)
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,7 @@ def main():
 
     root_logger = logging.getLogger()
     discord_log_formatter = root_logger.handlers[0]
+
     # Add a file handler to the root logger
     file_handler = logging.handlers.RotatingFileHandler(
         "./logs/RootPythia.log", mode="a", maxBytes=LOG_FILE_SIZE_MAX, backupCount=LOG_FILES_NUMBER
@@ -51,6 +52,14 @@ def main():
     file_handler.setFormatter(discord_log_formatter)
     root_logger.addHandler(file_handler)
     logging.info("FileHandler added to root logger it will write to '%s'", file_handler.stream.name)
+
+    # Add a specific file handler to save warnings and errors
+    warning_file_handler = logging.FileHandler(
+        "./logs/RootPythiaErrors.log", mode="a"
+    )
+    warning_file_handler.setLevel(logging.WARNING)
+    warning_file_handler.setFormatter(discord_log_formatter)
+    root_logger.addHandler(warning_file_handler)
 
     # are these call secure??
     logging.debug("discord token: %s", DISCORD_TOKEN)

--- a/src/main.py
+++ b/src/main.py
@@ -42,11 +42,14 @@ def main():
     # Setup a beautiful root logger
     discord.utils.setup_logging(root=True, level=LOG_LEVEL)
 
+    root_logger = logging.getLogger()
+    discord_log_formatter = root_logger.handlers[0]
     # Add a file handler to the root logger
     file_handler = logging.handlers.RotatingFileHandler(
         "./logs/RootPythia.log", mode="a", maxBytes=LOG_FILE_SIZE_MAX, backupCount=LOG_FILES_NUMBER
     )
-    logging.getLogger().addHandler(file_handler)
+    file_handler.setFormatter(discord_log_formatter)
+    root_logger.addHandler(file_handler)
     logging.info("FileHandler added to root logger it will write to '%s'", file_handler.stream.name)
 
     # are these call secure??

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,13 @@ import logging
 from os import getenv
 import sys
 
+# in bytes
+DEFAULT_LOG_FILE_SIZE_MAX = 10e6
+# the number of files the rotating file handler will generate at max
+# if exceeded it removes the older one
+# see https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler
+DEFAULT_LOG_FILES_NUMBER = 5
+
 import discord
 
 from bot import BOT as root_pythia
@@ -12,13 +19,29 @@ LOG_LEVEL = getenv("LOG_LEVEL")
 if LOG_LEVEL.isnumeric():
     LOG_LEVEL = int(LOG_LEVEL)
 
+LOG_FILE_SIZE_MAX = getenv("LOG_FILE_SIZE_MAX") or DEFAULT_LOG_FILE_SIZE_MAX
+try:
+    LOG_FILE_SIZE_MAX = int(LOG_FILE_SIZE_MAX)
+except ValueError as exc:
+    logging.exception("LOG_FILE_SIZE_MAX is not an integer")
+    exit(1)
+
+LOG_FILES_NUMBER = getenv("LOG_FILES_NUMBER") or DEFAULT_LOG_FILES_NUMBER
+try:
+    LOG_FILES_NUMBER = int(LOG_FILES_NUMBER)
+except ValueError as exc:
+    logging.exception("LOG_FILES_NUMBER is not an integer")
+    exit(1)
+
 
 def main():
     # Setup a beautiful root logger
     discord.utils.setup_logging(root=True, level=LOG_LEVEL)
 
     # Add a file handler to the root logger
-    file_handler = logging.RotatingFileHandler("./logs/RootPythia.log", mode='a', maxBytes=10e6, backupCount=5)
+    file_handler = logging.RotatingFileHandler(
+        "./logs/RootPythia.log", mode="a", maxBytes=LOG_FILE_SIZE_MAX, backupCount=LOG_FILES_NUMBER
+    )
     logging.getLogger().addHandler(file_handler)
     logging.info("FileHandler added to root logger it will write to '%s'", file_handler.stream.name)
 


### PR DESCRIPTION
How does it work:
share a volume with the host
host folder path configurable through LOG_FOLDER, container folder is /opt/root-pythia/logs
write to `RootPythia.log` file inside this folder, created if it doesn't exist, append to it if it exists
the same formatter than for the usual stream logging is uses (the discordpy one)
it uses a [`RotatingFileHandler`](https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler) to avoid log file to grow indefinitely
the max size of a log file is configurable through LOG_FILE_SIZE_MAX in bytes, default is 10MB
once the file has reached its max size it is renamed `RootPythia.log.1` silently by the handler which continues to wirte to a brand new `RootPythia.log` file
the number of old log file kept is configurable through LOG_FILES_NUMBER

everything has been tested