### PR TITLE
Change run.sh shebang from /bin/sh to /bin/bash to be able to use source

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 NAME="root-pythia"
 


### PR DESCRIPTION
#43 added logging to file and thus teh need to share a volume with the host, this volume used the env variable LOG_FOLDER which is made accessible to run.sh by a `source` command of the `.env.prod` env file, however source is `bash` only and doesn't exist in `sh`. Hence the need of changing the shebang